### PR TITLE
Cleanup: audit fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Firebase config. Copy this file to .env and fill in your own values.
+# Do not commit the real .env file.
+FIREBASE_API_KEY=your-api-key
+FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com
+FIREBASE_DATABASE_URL=https://your-project.firebaseio.com
+FIREBASE_PROJECT_ID=your-project
+FIREBASE_STORAGE_BUCKET=your-project.appspot.com
+FIREBASE_MESSAGING_SENDER_ID=your-sender-id

--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,12 @@
 /node_modules
 
 # misc
+.env
 .env.local
 .env.development.local
 .env.test.local
 .env.production.local
+!.env.example
 
 npm-debug.log*
 yarn-debug.log*

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Khoa Bui
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/components/containers/ListContainer.js
+++ b/components/containers/ListContainer.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { View, FlatList } from 'react-native';
 import { SearchBar, List, ListItem } from 'react-native-elements';
-import { loadMarkers } from '../../utils/actions';
+import { loadMarkers, unloadMarkers } from '../../utils/actions';
 import PropTypes from 'prop-types';
 
 class ListContainer extends Component {
@@ -15,8 +15,11 @@ class ListContainer extends Component {
     return <SearchBar placeholder="Type Here..." lightTheme round />;
   };
   componentDidMount() {
-    if (this.props.markers.length < 1 || this.props.markers == undefined)
+    if (this.props.markers == undefined || this.props.markers.length < 1)
       this.props.loadMarkers();
+  }
+  componentWillUnmount() {
+    this.props.unloadMarkers();
   }
   render() {
     return (
@@ -44,8 +47,9 @@ class ListContainer extends Component {
 }
 
 ListContainer.propTypes = {
-  markers: PropTypes.array.isRequired, 
-  loadMarkers: PropTypes.func.isRequired
+  markers: PropTypes.array.isRequired,
+  loadMarkers: PropTypes.func.isRequired,
+  unloadMarkers: PropTypes.func.isRequired
 };
 
 const mapStateToProps = (state) => ({
@@ -53,7 +57,8 @@ const mapStateToProps = (state) => ({
 });
 
 const mapDispatchToProps = (dispatch) => ({
-  loadMarkers: () => dispatch(loadMarkers())
+  loadMarkers: () => dispatch(loadMarkers()),
+  unloadMarkers: () => dispatch(unloadMarkers())
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(ListContainer);

--- a/components/containers/MapContainer.js
+++ b/components/containers/MapContainer.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { Platform, Text, ActivityIndicator } from 'react-native';
 import { connect } from 'react-redux';
-import { loadMarkers, sendMarker, setCurrentLocation } from '../../utils/actions';
+import { loadMarkers, unloadMarkers, sendMarker, setCurrentLocation } from '../../utils/actions';
 import { Constants, Location, Permissions } from 'expo';
 import { MapView } from 'expo';
 
@@ -42,10 +42,14 @@ class MapContainer extends Component {
     this.props.loadMarkers();
   }
 
+  componentWillUnmount() {
+    this.props.unloadMarkers();
+  }
+
   render() {
     if (this.state.errorMessage)
       return <Text style={{margin: 60, textAlign: 'center'}}>{this.state.errorMessage}</Text>;
-    else if (this.props.markers.length < 1 || this.props.markers == undefined || this.props.currentLatitude == undefined || this.props.currentLongitude == undefined)
+    else if (this.props.markers == undefined || this.props.currentLatitude == undefined || this.props.currentLongitude == undefined)
       return <ActivityIndicator size='large' style={{marginTop: '50%'}}/>;
     else 
       return (
@@ -62,8 +66,8 @@ class MapContainer extends Component {
           showsUserLocation = {true}
         >
           { 
-            this.props.markers.map((marker,index) => { 
-              return <MapView.Marker {...marker.marker} key={index} />;
+            this.props.markers.map((marker) => {
+              return <MapView.Marker {...marker.marker} key={marker.key} />;
             })
           }  
         </MapView>
@@ -80,6 +84,7 @@ const mapStateToProps = (state) => ({
 
 const mapDispatchToProps = (dispatch) => ({
   loadMarkers: () => dispatch(loadMarkers()),
+  unloadMarkers: () => dispatch(unloadMarkers()),
   sendMarker: (marker) => dispatch(sendMarker(marker)),
   setCurrentLocation: (location) => dispatch(setCurrentLocation(location))
 });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "photo-map-native",
+  "name": "iparcel-native",
   "version": "0.1.0",
   "private": true,
+  "license": "MIT",
   "devDependencies": {
     "babel-eslint": "^10.0.1",
     "eslint": "^5.6.1",

--- a/utils/actions.js
+++ b/utils/actions.js
@@ -2,16 +2,18 @@ import firebase from './firebase';
 
 export const loadMarkers = () => (dispatch) => {
   dispatch(startLoadMarkers());
-  firebase.database().ref('markers').once('value', (snapshot) => {
-    const data = snapshot.val();
+  // Use a single value listener. It fires with the full list on attach and on
+  // every change. This avoids loading each marker twice and lets us detach with
+  // off() on unmount.
+  firebase.database().ref('markers').on('value', (snapshot) => {
+    const data = snapshot.val() || {};
     const formattedData = Object.keys(data).map(key => ({ key, ...data[key] }));
     dispatch(finishLoadMarkers(formattedData));
   });
+};
 
-  firebase.database().ref('markers').on('child_added', (snapshot) => {
-    const marker = { key: snapshot.key, ...snapshot.val() };
-    dispatch(receiveMarker(marker));
-  });
+export const unloadMarkers = () => () => {
+  firebase.database().ref('markers').off('value');
 };
 
 export const startLoadMarkers = () => ({

--- a/utils/firebase.js
+++ b/utils/firebase.js
@@ -1,12 +1,14 @@
 import firebase from 'firebase';
 
+// Config is read from environment variables. See .env.example for the keys.
+// Do not commit real values. The old hardcoded project was deactivated.
 const config = {
-  apiKey: 'AIzaSyDYHpbMaanm8OSzYAt-3JQ6zaKV1UHKPIc',
-  authDomain: 'iparcel-a33e0.firebaseapp.com',
-  databaseURL: 'https://iparcel-a33e0.firebaseio.com',
-  projectId: 'iparcel-a33e0',
-  storageBucket: 'iparcel-a33e0.appspot.com',
-  messagingSenderId: '992822336983'
+  apiKey: process.env.FIREBASE_API_KEY,
+  authDomain: process.env.FIREBASE_AUTH_DOMAIN,
+  databaseURL: process.env.FIREBASE_DATABASE_URL,
+  projectId: process.env.FIREBASE_PROJECT_ID,
+  storageBucket: process.env.FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID
 };
 
 firebase.initializeApp(config);


### PR DESCRIPTION
This branch applies the confirmed audit fixes.

Bug fixes

- Marker load now uses one on value listener instead of once value plus child_added. Markers no longer enter the store twice.
- snapshot.val is guarded against null so an empty markers node no longer crashes the load path.
- Added an unloadMarkers action that calls off value. Both MapContainer and ListContainer detach on unmount so listeners no longer leak.
- Fixed the render guard order so the undefined check runs before length. An empty marker list no longer keeps the spinner up forever.
- Map markers now use the stable Firebase key as the React key instead of the array index.

Security

- Moved the hardcoded Firebase config out of source into process.env reads.
- Added .env.example with placeholder keys.
- Added .env to .gitignore with a keep rule for .env.example.

Housekeeping

- Renamed the package from photo-map-native to iparcel-native.
- Added an MIT LICENSE.